### PR TITLE
Rietveld's "too large to download" patches.

### DIFF
--- a/git-cl
+++ b/git-cl
@@ -815,6 +815,16 @@ def CmdPatch(args):
                             stdout=subprocess.PIPE)
     path = pipe.stdout.read().strip()
     url = 'https://%s%s' % (settings.GetServer(), path)
+    if len(path) == 0:
+        # There is no patch to download (patch may be too large, see
+        # http://code.google.com/p/rietveld/issues/detail?id=196).
+        # Try to download individual patches for each file instead,
+        # and concatenate them to obtain the complete patch.
+        grep = "grep -E -o '/download/issue[0-9]+_[0-9]+_[0-9]+.diff'"
+        pipe = subprocess.Popen("%s | %s" % (fetch, grep), shell=True,
+                                stdout=subprocess.PIPE)
+        paths = pipe.stdout.read().strip().split("\n")
+        url = 'https://%s{%s}' % (settings.GetServer(), ",".join(paths))
   else:
     # Assume it's a URL to the patch.
     match = re.match(r'https?://.*?/issue(\d+)_\d+.diff', input)


### PR DESCRIPTION
Allow to download "too large to download" patchsets.

Avoid the 404 error on patchsets that are "too large". Since patch download links are available for individual files, we donwload them and concatenate them to obtain the complete patch. curl allows us to do this in one go.

Workaround for Rietveld issue 196:
http://code.google.com/p/rietveld/issues/detail?id=196

Test bed: Rietveld issue 12980044
https://codereview.appspot.com/12980044/
